### PR TITLE
8340467: [mobile] duplicate symbols in libprefs.a on iOS

### DIFF
--- a/make/modules/java.prefs/Lib.gmk
+++ b/make/modules/java.prefs/Lib.gmk
@@ -30,7 +30,7 @@ include LibCommon.gmk
 ################################################################################
 
 # libprefs on macosx does not use the unix code
-ifeq ($(call isTargetOs, macosx), true)
+ifeq ($(call isTargetOs, macosx ios), true)
   LIBPREFS_EXCLUDE_SRC_PATTERNS := /unix/
 endif
 

--- a/make/modules/java.prefs/Lib.gmk
+++ b/make/modules/java.prefs/Lib.gmk
@@ -29,7 +29,7 @@ include LibCommon.gmk
 ## Build libprefs
 ################################################################################
 
-# libprefs on macosx does not use the unix code
+# libprefs on macosx or ios does not use the unix code
 ifeq ($(call isTargetOs, macosx ios), true)
   LIBPREFS_EXCLUDE_SRC_PATTERNS := /unix/
 endif


### PR DESCRIPTION
Using both the unix native code and the mac native code results in 2 JNI_OnLoad functions in the native prefs library.
Don't use unix code when creating native lib for java.prefs on ios. We should only use the macos code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340467](https://bugs.openjdk.org/browse/JDK-8340467): [mobile] duplicate symbols in libprefs.a on iOS (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [8e8676a0](https://git.openjdk.org/mobile/pull/29/files/8e8676a060424790ce6919d240658e1da5ef4774)
 * [Jose Pereda](https://openjdk.org/census#jpereda) (@jperedadnr - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/mobile.git pull/29/head:pull/29` \
`$ git checkout pull/29`

Update a local copy of the PR: \
`$ git checkout pull/29` \
`$ git pull https://git.openjdk.org/mobile.git pull/29/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29`

View PR using the GUI difftool: \
`$ git pr show -t 29`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/mobile/pull/29.diff">https://git.openjdk.org/mobile/pull/29.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/mobile/pull/29#issuecomment-2362009646)