### PR TITLE
8357119: Make Zero the default variant of HotSpot for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ tracking.
 
 ### Pre-requisites
 Following are the prerequisites to build JDK on Mac targeting iOS:
-1. Download and unzip pre-built JDK24 to be used as boot JDK
-2. Download the [support zip](https://download2.gluonhq.com/mobile/mobile-support-20250106.zip) which contains an ios build for libffi and cups. Unzip it in the root directory of the project.
+1. Download and install JDK24 for macOS. You can use the JDK you just built targeting macOS in the above note instead, but this is not recommended.
+2. Download the [support zip](https://download2.gluonhq.com/mobile/mobile-support-20250106.zip) which contains an ios build for libffi and cups. Unzip it in an easy to use location.
 3. Install `autoconf` on mac via homebrew: `brew install autoconf`
 
 ### Clone the mobile repository
@@ -31,27 +31,32 @@ git clone git@github.com:openjdk/mobile.git
 ```
 
 ### Configure
-Modify the configure script below so that it has the correct paths to your JDK24 directory,
-the unzipped 'support' directory, and the correct location of the iPhoneOS.platform.
+Modify the configure script below so that it has the correct paths to the unzipped 'support'
+directory, and the correct location of the iPhoneOS.platform.
 
 ```
 sh configure \
---with-conf-name=zero-ios-aarch64 \
 --disable-warnings-as-errors \
 --openjdk-target=aarch64-macos-ios \
---with-boot-jdk=/Users/abhinay/.sdkman/candidates/java/24.ea.29-open \
---with-jvm-variants=zero \
 --with-libffi-include=<support-dir-absolute-path>/libffi/include \
 --with-libffi-lib=<support-dir-absolute-path>/libffi/libs \
 --with-cups-include=<support-dir-absolute-path>/cups-2.3.6
 --with-sysroot=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk \
 ```
 
+If you need to tell configure the path of the boot JDK, or if configure fails with an error saying
+it can't find the boot JDK, for instance if you downloaded a JDK in compressed archive form rather
+than with an installer, you can pass the following option to configure:
+
+```
+--with-boot-jdk=<java-directory-absolute-path>
+```
+
 ### Build static image
 Execute the `make` command:
 
 ```
-make CONF=zero-ios-aarch64 static-libs-image
+make CONF=ios-aarch64-zero-release static-libs-image
 ```
 
-Once the build is successful, it should have created a directory in `build/zero-ios-aarch64/images/static-libs/lib/zero` with a file `libjvm.a`.
+Once the build is successful, it should have created a directory in `build/ios-aarch64-zero-release/images/static-libs/lib/zero` with a file `libjvm.a`.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ sh configure \
 
 If you need to tell configure the path of your boot JDK, or if configure fails with an error saying
 it can't find a boot JDK, for instance if you downloaded a JDK in compressed archive form rather
-than with an installer, you can pass `--with-boot-jdk=<java-directory-path>` to configure:
+than with an installer, you can pass `--with-boot-jdk=<java-directory-path>` to configure.
 
 For iOS the default JVM used is Zero, since iOS has no writeable and executable sections. However, if
 you plan to run the JDK on the simulator for testing purposes, you can use the other JVM variants such

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ tracking.
 
 ### Pre-requisites
 Following are the prerequisites to build JDK on Mac targeting iOS:
-1. Download and install JDK24 for macOS. You can use the JDK you just built targeting macOS in the above note instead, but this is not recommended.
+1. Download and install JDK24 for macOS. You can use the JDK you just built targeting macOS in the above note instead.
 2. Download the [support zip](https://download2.gluonhq.com/mobile/mobile-support-20250106.zip) which contains an ios build for libffi and cups. Unzip it in an easy to use location.
 3. Install `autoconf` on mac via homebrew: `brew install autoconf`
 
@@ -38,19 +38,21 @@ directory, and the correct location of the iPhoneOS.platform.
 sh configure \
 --disable-warnings-as-errors \
 --openjdk-target=aarch64-macos-ios \
---with-libffi-include=<support-dir-absolute-path>/libffi/include \
---with-libffi-lib=<support-dir-absolute-path>/libffi/libs \
---with-cups-include=<support-dir-absolute-path>/cups-2.3.6
+--with-libffi-include=<support-dir-path>/libffi/include \
+--with-libffi-lib=<support-dir-path>/libffi/libs \
+--with-cups-include=<support-dir-path>/cups-2.3.6
 --with-sysroot=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk \
 ```
 
-If you need to tell configure the path of the boot JDK, or if configure fails with an error saying
-it can't find the boot JDK, for instance if you downloaded a JDK in compressed archive form rather
-than with an installer, you can pass the following option to configure:
+If you need to tell configure the path of your boot JDK, or if configure fails with an error saying
+it can't find a boot JDK, for instance if you downloaded a JDK in compressed archive form rather
+than with an installer, you can pass `--with-boot-jdk=<java-directory-path>` to configure:
 
-```
---with-boot-jdk=<java-directory-absolute-path>
-```
+For iOS the default JVM used is Zero, since iOS has no writeable and executable sections. However, if
+you plan to run the JDK on the simulator for testing purposes, you can use the other JVM variants such
+as Server. To do this, pass `--with-jvm-variants=server` to configure (Or any other valid option, which
+are, in no particular order: server, client, minimal, core, zero, custom). Do note that passing zero to
+this option is redundant since Zero is already the default for iOS.
 
 ### Build static image
 Execute the `make` command:

--- a/make/autoconf/hotspot.m4
+++ b/make/autoconf/hotspot.m4
@@ -54,7 +54,11 @@ AC_DEFUN_ONCE([HOTSPOT_SETUP_JVM_VARIANTS],
       zero custom) @<:@server@:>@])])
 
   if test "x$with_jvm_variants" = x; then
-    with_jvm_variants="server"
+    if test "x$OPENJDK_TARGET_OS" = xios; then
+      with_jvm_variants="zero"
+    else
+      with_jvm_variants="server"
+    fi
   fi
   JVM_VARIANTS_OPT="$with_jvm_variants"
 
@@ -73,6 +77,10 @@ AC_DEFUN_ONCE([HOTSPOT_SETUP_JVM_VARIANTS],
   # Also use minimal, not minimal1 (which is kept for backwards compatibility).
   JVM_VARIANTS=`$ECHO $JVM_VARIANTS_OPT | $SED -e 's/,/ /g' -e 's/minimal1/minimal/'`
   AC_MSG_RESULT([$JVM_VARIANTS])
+
+  if test "x$OPENJDK_TARGET_OS" = xios; then
+    VALID_JVM_VARIANTS="zero"
+  fi
 
   # Check that the selected variants are valid
   UTIL_GET_NON_MATCHING_VALUES(INVALID_VARIANTS, $JVM_VARIANTS, \

--- a/make/autoconf/hotspot.m4
+++ b/make/autoconf/hotspot.m4
@@ -78,10 +78,6 @@ AC_DEFUN_ONCE([HOTSPOT_SETUP_JVM_VARIANTS],
   JVM_VARIANTS=`$ECHO $JVM_VARIANTS_OPT | $SED -e 's/,/ /g' -e 's/minimal1/minimal/'`
   AC_MSG_RESULT([$JVM_VARIANTS])
 
-  if test "x$OPENJDK_TARGET_OS" = xios; then
-    VALID_JVM_VARIANTS="zero"
-  fi
-
   # Check that the selected variants are valid
   UTIL_GET_NON_MATCHING_VALUES(INVALID_VARIANTS, $JVM_VARIANTS, \
       $VALID_JVM_VARIANTS)


### PR DESCRIPTION
Currently, the Zero variant of HotSpot must be manually selected for mobile to compile properly for iOS, since iOS does not allow writeable and executable sections. Since Zero is, to my knowledge, the only valid HotSpot variant for iOS, this default should be handled by the build rather than require the developer to have specific knowledge about iOS and the mobile fork. I also took the opportunity to explicitly disallow selecting other JVM variants at all for iOS, this can be rolled back if my assumption turns out to be incorrect. While here, also touch up the build docs a little.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8357119](https://bugs.openjdk.org/browse/JDK-8357119): Make Zero the default variant of HotSpot for iOS (**Enhancement** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/mobile.git pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.org/mobile.git pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/mobile/pull/35.diff">https://git.openjdk.org/mobile/pull/35.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/mobile/pull/35#issuecomment-2886044228)
</details>
