### PR TITLE
8359163: Fix path to current module on ios

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -473,13 +473,8 @@ void os::init_system_properties_values() {
         *pslash = '\0';          // Get rid of /lib.
       }
     }
-    Arguments::set_java_home(buf);
-#else
-    size_t nlen = strlen(user_home_dir) + 11;
-    char *iosuser_home = NEW_C_HEAP_ARRAY(char, nlen, mtInternal);
-    snprintf(iosuser_home, nlen, "%s/Documents", user_home_dir);
-    Arguments::set_java_home(iosuser_home);
 #endif
+    Arguments::set_java_home(buf);
     if (!set_boot_path('/', ':')) {
         vm_exit_during_initialization("Failed setting boot class path.", nullptr);
     }


### PR DESCRIPTION
Minimize ios-specific logic to calculate the location for java_home.
The java_home property should be based on the jvm_path, and not on the user_home

Fix JDK-8359163

This patch still has ios-specific logic, e.g. we don't have a {client/server} suffix to the jvm home. More important, though, is that we do not want to point to userspace for the location of the jvm modules etc itself. Those should be derived from the installed application location, which matches the jvm_home property.
Applying this patch removes one more location where the mobile repository differs from upstream jdk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8359163](https://bugs.openjdk.org/browse/JDK-8359163): Fix path to current module on ios (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/mobile.git pull/39/head:pull/39` \
`$ git checkout pull/39`

Update a local copy of the PR: \
`$ git checkout pull/39` \
`$ git pull https://git.openjdk.org/mobile.git pull/39/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 39`

View PR using the GUI difftool: \
`$ git pr show -t 39`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/mobile/pull/39.diff">https://git.openjdk.org/mobile/pull/39.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/mobile/pull/39#issuecomment-3132785101)
</details>
