### PR TITLE
8374535: IOS uses different path for modules

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1515,11 +1515,7 @@ bool os::set_boot_path(char fileSep, char pathSep) {
   struct stat st;
 
   // modular image if "modules" jimage exists
-#ifndef __IOS__
   char* jimage = format_boot_path("%/lib/" MODULES_IMAGE_NAME, home, home_len, fileSep, pathSep);
-#else
-  char* jimage = format_boot_path("%/Documents/lib/" MODULES_IMAGE_NAME, home, home_len, fileSep, pathSep);
-#endif
   if (jimage == nullptr) return false;
   bool has_jimage = (os::stat(jimage, &st) == 0);
   if (has_jimage) {


### PR DESCRIPTION
I spent like 20 hours debugging this. I am shipping an app for iOS which uses Java. The exploded modules works fine. But when I tried to publish my app I got this error https://github.com/openjdk-mobile/ios-tools/issues/61

So I then built a module file, but was getting this error that it couldn't find the module file. I read the code and found on iOS it looks at the `JAVA_HOME/Documents/lib/module` sure whatever I did that. And the JVM still failed to initialize. After debugging for what felt like forever

I found that https://github.com/openjdk/mobile/blob/205325c987df20d8d72372f45910137d61da0850/src/hotspot/share/classfile/classLoader.cpp#L1418-L1420 is hard code to search `Java_HOME/lib` which is what Default Java uses.

So I removed the custom pathing check for the module file for iOS which is seen in this PR diff and it worked 🥳 . I don't know why that `ifndef` was added, but I don't think it should be there. I think we should use the defaults for Java, as Java's JVM initialization errors aren't that helpful, so we shouldn't be doing magic for iOS. If I want my modules in `Documents` I will set my `JAVA_HOME` myself. Anyways thought I would make a PR to help out this cause 🔥. Also I am SO HAPPY my java app works now on iOS. Thank you guys so much <3.

**TLDR** Jimage module file exists check for iOS is different then Jimage module path we read from.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8374535](https://bugs.openjdk.org/browse/JDK-8374535): IOS uses different path for modules (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/mobile.git pull/43/head:pull/43` \
`$ git checkout pull/43`

Update a local copy of the PR: \
`$ git checkout pull/43` \
`$ git pull https://git.openjdk.org/mobile.git pull/43/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 43`

View PR using the GUI difftool: \
`$ git pr show -t 43`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/mobile/pull/43.diff">https://git.openjdk.org/mobile/pull/43.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/mobile/pull/43#issuecomment-3832200637)
</details>
