### PR TITLE
8374522: Mobile: Add iOS as a platform in OperatingSystem.java

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/OperatingSystem.java
+++ b/src/java.base/share/classes/jdk/internal/util/OperatingSystem.java
@@ -81,6 +81,10 @@ public enum OperatingSystem {
      * The AIX Operating system.
      */
     AIX,
+    /**
+     * The iOS Operating system.
+     */
+    IOS,
     ;
 
     // The current OperatingSystem
@@ -99,7 +103,8 @@ public enum OperatingSystem {
      */
     @ForceInline
     public static boolean isMacOS() {
-        return PlatformProps.TARGET_OS_IS_MACOS;
+        // Treat iOS as macOS for compatibility with existing libraries unless specific IOS checks exist
+        return PlatformProps.TARGET_OS_IS_MACOS || current() == IOS;
     }
 
     /**
@@ -116,6 +121,13 @@ public enum OperatingSystem {
     @ForceInline
     public static boolean isAix() {
         return PlatformProps.TARGET_OS_IS_AIX;
+    }
+
+    /**
+     * {@return {@code true} if built for the iOS operating system}
+     */
+    public static boolean isIos() {
+        return current() == IOS;
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/util/OperatingSystem.java
+++ b/src/java.base/share/classes/jdk/internal/util/OperatingSystem.java
@@ -59,6 +59,7 @@ import jdk.internal.vm.annotation.ForceInline;
  *          case AIX->32768;
  *          case MACOS->49152;
  *          case WINDOWS->49152;
+ *          case IOS->49152;
  *      };
  * }
  *}
@@ -103,8 +104,7 @@ public enum OperatingSystem {
      */
     @ForceInline
     public static boolean isMacOS() {
-        // Treat iOS as macOS for compatibility with existing libraries unless specific IOS checks exist
-        return PlatformProps.TARGET_OS_IS_MACOS || current() == IOS;
+        return PlatformProps.TARGET_OS_IS_MACOS;
     }
 
     /**
@@ -127,7 +127,7 @@ public enum OperatingSystem {
      * {@return {@code true} if built for the iOS operating system}
      */
     public static boolean isIos() {
-        return current() == IOS;
+        return PlatformProps.TARGET_OS_IS_IOS;
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/util/PlatformProps.java.template
+++ b/src/java.base/share/classes/jdk/internal/util/PlatformProps.java.template
@@ -39,6 +39,7 @@ class PlatformProps {
     static final boolean TARGET_OS_IS_MACOS   = "@@OPENJDK_TARGET_OS@@" == "macos";
     static final boolean TARGET_OS_IS_WINDOWS = "@@OPENJDK_TARGET_OS@@" == "windows";
     static final boolean TARGET_OS_IS_AIX     = "@@OPENJDK_TARGET_OS@@" == "aix";
+    static final boolean TARGET_OS_IS_IOS     = "@@OPENJDK_TARGET_OS@@" == "ios";
 
     // The Architecture value for the current architecture
     static final String CURRENT_ARCH_STRING = "@@OPENJDK_TARGET_CPU@@";


### PR DESCRIPTION
I don't know how but Kotlin calls OperatingSystem.IOS, adding iOS as an OperatingSystem fixed my problems, it had something to do with Kotlin's logging library if I remember correctly during initialization it calls something with OperatingSystem.IOS then it panics because IOS isn't an option in the OperatingSystem Class

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8374522](https://bugs.openjdk.org/browse/JDK-8374522): Mobile: Add iOS as a platform in OperatingSystem.java (**Enhancement** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/mobile.git pull/44/head:pull/44` \
`$ git checkout pull/44`

Update a local copy of the PR: \
`$ git checkout pull/44` \
`$ git pull https://git.openjdk.org/mobile.git pull/44/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 44`

View PR using the GUI difftool: \
`$ git pr show -t 44`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/mobile/pull/44.diff">https://git.openjdk.org/mobile/pull/44.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/mobile/pull/44#issuecomment-3832201203)
</details>
