### PR TITLE
8380088: IOS: jit_write_protect_np not allowed

### DIFF
--- a/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
@@ -567,7 +567,9 @@ THREAD_LOCAL bool os::_jit_exec_enabled;
 void os::current_thread_enable_wx(WXMode mode) {
   bool exec_enabled = mode != WXWrite;
   if (exec_enabled != _jit_exec_enabled NOT_PRODUCT( || DefaultWXWriteMode == WXWrite)) {
+#ifndef __IOS__
     permit_forbidden_function::pthread_jit_write_protect_np(exec_enabled);
+#endif
     _jit_exec_enabled = exec_enabled;
   }
 }

--- a/src/hotspot/share/runtime/thread.inline.hpp
+++ b/src/hotspot/share/runtime/thread.inline.hpp
@@ -68,7 +68,9 @@ inline void Thread::init_wx() {
   assert(this == Thread::current(), "should only be called for current thread");
   assert(!_wx_init, "second init");
   _wx_state = WXWrite;
+#ifndef __IOS__
   permit_forbidden_function::pthread_jit_write_protect_np(false);
+#endif
   os::current_thread_enable_wx(_wx_state);
   // Side effect: preload base address of libjvm
   guarantee(os::address_is_in_vm(CAST_FROM_FN_PTR(address, &dummy)), "must be");

--- a/src/hotspot/share/utilities/permitForbiddenFunctions.hpp
+++ b/src/hotspot/share/utilities/permitForbiddenFunctions.hpp
@@ -70,9 +70,11 @@ inline void* realloc(void* ptr, size_t size) { return ::realloc(ptr, size); }
 
 inline char* strdup(const char* s) { return ::strdup(s); }
 
+#ifndef __IOS__
 MACOS_AARCH64_ONLY( \
   inline void pthread_jit_write_protect_np(int enabled) { return ::pthread_jit_write_protect_np(enabled); } \
 )
+#endif
 
 END_ALLOW_FORBIDDEN_FUNCTIONS
 } // namespace permit_forbidden_function


### PR DESCRIPTION
Do not try to invoke pthread_jit_write_protect_np when compiling for iOS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8380088](https://bugs.openjdk.org/browse/JDK-8380088): IOS: jit_write_protect_np not allowed (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/mobile.git pull/47/head:pull/47` \
`$ git checkout pull/47`

Update a local copy of the PR: \
`$ git checkout pull/47` \
`$ git pull https://git.openjdk.org/mobile.git pull/47/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 47`

View PR using the GUI difftool: \
`$ git pr show -t 47`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/mobile/pull/47.diff">https://git.openjdk.org/mobile/pull/47.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/mobile/pull/47#issuecomment-4063634926)
</details>
